### PR TITLE
Fix logic for volume control

### DIFF
--- a/player/assets/javascripts/canvas.js
+++ b/player/assets/javascripts/canvas.js
@@ -240,9 +240,9 @@ function toggleMuteState(evt) {
         volumeCtrl.value = 0;
     }
     else {
-        // if no previous state, set volume to "low" (default value)
-        if (previousVolumeState == '')
-            evt.target.className = 'low';
+        // if volume is already zero, do nothing on pressing mute button again
+        if (video.volume == 0)
+            return;   
         else 
             evt.target.className = previousVolumeState;
         previousVolumeState = currentVolumeState;


### PR DESCRIPTION
Fix volume to remain muted on clicking mute button when volume is already zero, to be consistent with general video player behaviour.
