### PR TITLE
Set singleRun to true

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -77,7 +77,7 @@ module.exports = function(config) {
 
     // Continuous Integration mode
     // if true, Karma captures browsers, runs the tests and exits
-    singleRun: false,
+    singleRun: true,
 
     // Concurrency level
     // how many browser should be started simultaneous


### PR DESCRIPTION
Ensure karma test stops in travis (does not keep waiting and runs infinitely)
In development when doing self testing, can set this option to false for karma to watch changes and update the test.
